### PR TITLE
fix: #1 add release phase to collect static files

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,9 @@
 build:
   docker:
     web: Dockerfile
+release:
+  image: web
+  command:
+    - python manage.py collectstatic --noinput
 run:
   web: gunicorn config.wsgi:application --bind 0.0.0.0:$PORT


### PR DESCRIPTION
This PR may fix #1.
 
Added configuration to run `collectstatic` before every new release. That way, storing static files meant for prod locally and pushing them to github is unnecessary. There shouldn't be any issue with the [heroku ephemeral file system](https://devcenter.heroku.com/articles/active-storage-on-heroku) since dyno will not be on when the release task will make changes to the file system.