### PR TITLE
fix: #1 serve static, collectstatic, build env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,17 @@ COPY Pipfile Pipfile.lock /app/
 RUN pip install pipenv && pipenv install --system
 
 COPY . /app/
+
+# Add args to be able to collectstatic as 
+# heroku config vars not available during build time
+
+ARG SECRET_KEY
+ARG DEBUG
+ARG JWT_ALGORITHM
+ARG JWT_SECRET_KEY
+ARG REDIS_URL
+ARG CLOUDINARY_NAME
+ARG CLOUDINARY_API_KEY
+ARG CLOUDINARY_API_SECRET
+
+RUN python manage.py collectstatic --noinput

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,14 @@
 build:
   docker:
     web: Dockerfile
+  config:
+    SECRET_KEY: static
+    DEBUG: False
+    JWT_ALGORITHM: static
+    JWT_SECRET_KEY: static
+    REDIS_URL: static
+    CLOUDINARY_NAME: static 
+    CLOUDINARY_API_KEY: static
+    CLOUDINARY_API_SECRET: static
 run:
   web: gunicorn config.wsgi:application --bind 0.0.0.0:$PORT


### PR DESCRIPTION
This PR:

- adds the collectstatic command in the dockerfile
- tricks the code to run by adding dummy values for [env vars just used during build time](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#setting-build-time-environment-variables). No security issues.